### PR TITLE
Select escape character

### DIFF
--- a/arrow_pd_parser/parse.py
+++ b/arrow_pd_parser/parse.py
@@ -3,9 +3,30 @@ from pyarrow import csv
 from arrow_pd_parser.pa_pd import arrow_to_pandas
 
 
-def pa_read_csv(csv_path, test_col_types):
-    csv_co = csv.ConvertOptions(column_types=test_col_types)
-    pa_csv_table = csv.read_csv(csv_path, convert_options=csv_co)
+def pa_read_csv(
+    csv_path,
+    test_col_types,
+    convert_options=None,
+    parse_options=None,
+    read_options=None,
+):
+    if convert_options is None:
+        convert_options = {}
+    if parse_options is None:
+        parse_options = {}
+    if read_options is None:
+        read_options = {}
+
+    csv_convert = csv.ConvertOptions(column_types=test_col_types, **convert_options)
+    csv_parse = csv.ParseOptions(**parse_options)
+    csv_read = csv.ReadOptions(**read_options)
+
+    pa_csv_table = csv.read_csv(
+        csv_path,
+        convert_options=csv_convert,
+        parse_options=csv_parse,
+        read_options=csv_read,
+    )
     return pa_csv_table
 
 
@@ -17,9 +38,12 @@ def pa_read_csv_to_pandas(
     pd_string: bool = True,
     pd_date_type: str = "datetime_object",
     pd_timestamp_type: str = "datetime_object",
+    convert_options=None,
+    parse_options=None,
+    read_options=None,
 ):
 
-    arrow_table = pa_read_csv(csv_path, test_col_types)
+    arrow_table = pa_read_csv(csv_path, test_col_types, convert_options, parse_options, read_options)
     df = arrow_to_pandas(
         arrow_table,
         pd_boolean=pd_boolean,
@@ -30,4 +54,3 @@ def pa_read_csv_to_pandas(
     )
 
     return df
-  

--- a/arrow_pd_parser/parse.py
+++ b/arrow_pd_parser/parse.py
@@ -43,7 +43,9 @@ def pa_read_csv_to_pandas(
     read_options=None,
 ):
 
-    arrow_table = pa_read_csv(csv_path, test_col_types, convert_options, parse_options, read_options)
+    arrow_table = pa_read_csv(
+        csv_path, test_col_types, convert_options, parse_options, read_options
+    )
     df = arrow_to_pandas(
         arrow_table,
         pd_boolean=pd_boolean,

--- a/tests/data/csv_options_test.csv
+++ b/tests/data/csv_options_test.csv
@@ -1,0 +1,3 @@
+i,my_string
+escaped comma in string with single quotes,'dsfasd,dsffadsf'
+escaped comma in string with no quotes,dsfasd\,dsffadsf

--- a/tests/data/csv_options_test.csv
+++ b/tests/data/csv_options_test.csv
@@ -3,5 +3,6 @@ i;my_string;left_out_col
 escaped delimiter in string with single quotes;'dsfasd;dsffadsf';not included
 escaped delimiter in string with no quotes;dsfasd\;dsffadsf;not included
 specific null value;NULL_STRING;not included
-string with newline;lthis text\\nhas two lines;not included
+string with newline;'this text
+has a line break';not included
 comma no longer delimits;this text, like so, has commas;not included

--- a/tests/data/csv_options_test.csv
+++ b/tests/data/csv_options_test.csv
@@ -1,3 +1,7 @@
-i,my_string
-escaped comma in string with single quotes,'dsfasd,dsffadsf'
-escaped comma in string with no quotes,dsfasd\,dsffadsf
+a line of random text before the actual csv content
+i;my_string;left_out_col
+escaped delimiter in string with single quotes;'dsfasd;dsffadsf';not included
+escaped delimiter in string with no quotes;dsfasd\;dsffadsf;not included
+specific null value;NULL_STRING;not included
+string with newline;lthis text\\nhas two lines;not included
+comma no longer delimits;this text, like so, has commas;not included

--- a/tests/test_str_conformance.py
+++ b/tests/test_str_conformance.py
@@ -19,3 +19,21 @@ def test_string(in_type, pd_old_type, pd_new_type):
         "tests/data/string_type.csv", test_col_types, pd_string=True
     )
     assert str(df_new.my_string.dtype) == pd_new_type
+
+
+@pytest.mark.parametrize(
+    "in_type,pd_old_type,pd_new_type",
+    [("string", "object", "string")],
+)
+def test_csv_options(in_type, pd_old_type, pd_new_type):
+    parse_options = {"quote_char": "'", "escape_char": "\\"}
+    test_col_types = {"string_col": getattr(pa, "string")()}
+    df_old = pa_read_csv_to_pandas(
+        "tests/data/csv_options_test.csv", test_col_types, pd_string=False, parse_options=parse_options
+    )
+    assert str(df_old.my_string.dtype) == pd_old_type
+
+    df_new = pa_read_csv_to_pandas(
+        "tests/data/csv_options_test.csv", test_col_types, pd_string=True, parse_options=parse_options
+    )
+    assert str(df_new.my_string.dtype) == pd_new_type

--- a/tests/test_str_conformance.py
+++ b/tests/test_str_conformance.py
@@ -5,8 +5,7 @@ from arrow_pd_parser.parse import pa_read_csv_to_pandas
 
 
 @pytest.mark.parametrize(
-    "in_type,pd_old_type,pd_new_type",
-    [("string", "object", "string")],
+    "in_type,pd_old_type,pd_new_type", [("string", "object", "string")],
 )
 def test_string(in_type, pd_old_type, pd_new_type):
     test_col_types = {"string_col": getattr(pa, "string")()}
@@ -22,18 +21,30 @@ def test_string(in_type, pd_old_type, pd_new_type):
 
 
 @pytest.mark.parametrize(
-    "in_type,pd_old_type,pd_new_type",
-    [("string", "object", "string")],
+    "in_type,pd_old_type,pd_new_type", [("string", "object", "string")],
 )
 def test_csv_options(in_type, pd_old_type, pd_new_type):
-    parse_options = {"quote_char": "'", "escape_char": "\\"}
     test_col_types = {"string_col": getattr(pa, "string")()}
-    df_old = pa_read_csv_to_pandas(
-        "tests/data/csv_options_test.csv", test_col_types, pd_string=False, parse_options=parse_options
-    )
-    assert str(df_old.my_string.dtype) == pd_old_type
+    parse_options = {
+        "quote_char": "'",
+        "escape_char": "\\",
+        "delimiter": ";",
+        "newlines_in_values": True,
+    }
+    read_options = {"skip_rows": 1}
+    convert_options = {
+        "include_columns": ["i", "my_string", "nonexistent_column"],
+        "include_missing_columns": True,
+        "null_values": ["NULL_STRING"],
+    }
 
-    df_new = pa_read_csv_to_pandas(
-        "tests/data/csv_options_test.csv", test_col_types, pd_string=True, parse_options=parse_options
+    df = pa_read_csv_to_pandas(
+        "tests/data/csv_options_test.csv",
+        test_col_types,
+        pd_string=False,
+        parse_options=parse_options,
+        convert_options=convert_options,
+        read_options=read_options,
     )
-    assert str(df_new.my_string.dtype) == pd_new_type
+    print(df.columns.tolist())
+    assert df.columns.tolist() == ["i", "my_string", "nonexistent_column"]

--- a/tests/test_str_conformance.py
+++ b/tests/test_str_conformance.py
@@ -2,6 +2,8 @@ import pytest
 import pyarrow as pa
 
 from arrow_pd_parser.parse import pa_read_csv_to_pandas
+from pandas.testing import assert_series_equal
+from pandas import Series
 
 
 @pytest.mark.parametrize(
@@ -36,8 +38,8 @@ def test_csv_options(in_type, pd_old_type, pd_new_type):
         "include_columns": ["i", "my_string", "nonexistent_column"],
         "include_missing_columns": True,
         "null_values": ["NULL_STRING"],
+        "strings_can_be_null": True,
     }
-
     df = pa_read_csv_to_pandas(
         "tests/data/csv_options_test.csv",
         test_col_types,
@@ -46,5 +48,14 @@ def test_csv_options(in_type, pd_old_type, pd_new_type):
         convert_options=convert_options,
         read_options=read_options,
     )
-    print(df.columns.tolist())
+
+    expected = [
+        "dsfasd;dsffadsf",
+        "dsfasd;dsffadsf",
+        None,
+        "this text\nhas a line break",
+        "this text, like so, has commas"
+    ]
     assert df.columns.tolist() == ["i", "my_string", "nonexistent_column"]
+    assert df["nonexistent_column"].isnull().all()
+    assert_series_equal(df["my_string"], Series(expected, name="my_string"))

--- a/tests/test_str_conformance.py
+++ b/tests/test_str_conformance.py
@@ -54,7 +54,7 @@ def test_csv_options(in_type, pd_old_type, pd_new_type):
         "dsfasd;dsffadsf",
         None,
         "this text\nhas a line break",
-        "this text, like so, has commas"
+        "this text, like so, has commas",
     ]
     assert df.columns.tolist() == ["i", "my_string", "nonexistent_column"]
     assert df["nonexistent_column"].isnull().all()


### PR DESCRIPTION
This is to solve #14 , which is about quote and escape characters. But as suggested there it seemed more useful to add all the csv reading options as unpackable keyword arguments. 

Arrow's csv reader takes its options in three parts: ConvertOptions, ParseOptions and ReadOptions. So I've allowed each of these to be passed in as a separate dictionary. I'm not certain this is the neatest way to do it, so very open to suggestions on improving that!

I've also added some tests to check that these additional options are working as expected. 