### PR TITLE
Metadata should take a list of columns rather than a single instance

### DIFF
--- a/arrow_pd_parser/caster.py
+++ b/arrow_pd_parser/caster.py
@@ -197,7 +197,7 @@ def cast_pandas_column_to_schema(
 
     # get type_category if not exist
     if "type_category" not in metacol:
-        tmp_meta = Metadata(columns=metacol)
+        tmp_meta = Metadata(columns=[metacol])
         tmp_meta.set_col_type_category_from_types()
         metacol = tmp_meta.get_column(metacol["name"])
 


### PR DESCRIPTION
`caster.cast_pandas_column_to_schema` fails validation because if `type_category` is missing from the column schema it creates a new schema with just that column, but does not put this in a list which means it fails validation.

(I'm not sure why) this hasn't been a problem before as current pipelines use this method.)